### PR TITLE
Released version 2.0.0

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -9,7 +9,7 @@ namespace: ieisystem
 name: inmanage
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 1.2.1
+version: 2.0.0
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md


### PR DESCRIPTION
resolved breaking changes that were mistakenly released in version 1.2.0.